### PR TITLE
fix: make UI class name suffix camelcase in template

### DIFF
--- a/template/{{project_name}}/bec_widgets/widgets/{% yield widget_plugin from widget_plugins %}{{ widget_plugin.module }}{% endyield %}/{% if widget_plugin.use_ui %}{{ widget_plugin.module }}.ui{% endif %}.jinja
+++ b/template/{{project_name}}/bec_widgets/widgets/{% yield widget_plugin from widget_plugins %}{{ widget_plugin.module }}{% endyield %}/{% if widget_plugin.use_ui %}{{ widget_plugin.module }}.ui{% endif %}.jinja
@@ -1,8 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-    <class>{{ widget_plugin.class }}</class>
-    <widget class="QWidget" name="{{ widget_plugin.module | snake_to_camel }}">
-    </widget>
-    <resources />
-    <connections />
+ <class>{{ widget_plugin.module | snake_to_camel }}</class>
+ <widget class="QWidget" name="{{ widget_plugin.module | snake_to_camel }}">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>150</width>
+    <height>150</height>
+   </rect>
+  </property>
+ </widget>
+ <resources/>
+ <connections/>
 </ui>


### PR DESCRIPTION
For some reason, bec-designer overwrites the initial `<class>` tag with one formatted in camelCase, which leads to different capitalisation in the compiled python file after recompiling. This change makes the initially generated XML file with the correct name.