### PR TITLE
fix: add macro dir and readme

### DIFF
--- a/template/{{project_name}}/macros/README.md.jinja
+++ b/template/{{project_name}}/macros/README.md.jinja
@@ -1,0 +1,6 @@
+# Macros
+
+This directory is intended to store macros which will be loaded automatically when starting BEC.
+Macros are small functions to make repetitive tasks easier. Functions defined in python files in this directory will be accessible from the BEC console.
+Please do not put any code outside of function definitions here. If you wish for code to be automatically run when starting BEC, see the startup script at {{project_name}}/bec_ipython_client/startup/post_startup.py
+For a guide on writing macros, please see: https://bec.readthedocs.io/en/latest/user/command_line_interface.html#how-to-write-a-macro


### PR DESCRIPTION
Adds a dir to store macros and a readme guiding users to the documentation on how to write them
Fixes #9 