### PR TITLE
fix: actually include merge conflict lint

### DIFF
--- a/template/.gitea/workflows/ci.yml.jinja
+++ b/template/.gitea/workflows/ci.yml.jinja
@@ -53,9 +53,10 @@ jobs:
           ref: "{% raw %}${{ inputs.BEC_PLUGIN_REPO_BRANCH || github.head_ref || github.sha }}{% endraw %}"
           path: ./{{ project_name }}
 
-      - name: Lint for merge conflicts
-        run: |
-          
+      - name: Lint for merge conflicts from template updates
+        shell: bash
+        # Find all Copier conflicts except this line
+        run: '! grep -r "<<<<<<< before updating" | grep -v "grep -r \"<<<<<<< before updating"'
 
       - name: Checkout BEC Core
         uses: actions/checkout@v4


### PR DESCRIPTION
tested passing on https://gitea.psi.ch/bec/csaxs_bec/actions/runs/674/jobs/0
tested expected failing on https://gitea.psi.ch/bec/microxas_bec/actions/runs/7/jobs/0

This step greps for any merge conflicts from template updates, and will display the files that have them