### PR TITLE
fix: python env in create_update_pr

### DIFF
--- a/template/.gitea/workflows/create_update_pr.yml.jinja
+++ b/template/.gitea/workflows/create_update_pr.yml.jinja
@@ -17,14 +17,14 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-    
+
       - name: Install tools
         run: |
-          pip install copier PySide6
+          pip install copier PySide6 bec_lib
 
       - name: Checkout
         uses: actions/checkout@v4
-    
+
       - name: Perform update
         run: |
           git config --global user.email "bec_ci_staging@psi.ch"
@@ -35,8 +35,10 @@ jobs:
           git checkout -b $branch
 
           echo "Running copier update..."
-          output="$(copier update --trust --defaults --conflict inline 2>&1)"
-          echo "$output"
+          copier update --trust --defaults --conflict inline 2>&1 | tee copier.log
+          status=${PIPESTATUS[0]}
+          output="$(cat copier.log)"
+          echo $output
           msg="$(printf '%s\n' "$output" | head -n 1)"
 
           if ! grep -q "make_commit: true" .copier-answers.yml ; then


### PR DESCRIPTION
creates a virtualenv in the `create_update_pr` workflow because using the runner system is broken apparently

working run: https://gitea.psi.ch/bec/bec_testing_plugin/actions/runs/143646/jobs/188776
example PR: https://gitea.psi.ch/bec/bec_testing_plugin/pulls/3